### PR TITLE
front: set replace=true on navigate

### DIFF
--- a/frontend/src/components/Main.tsx
+++ b/frontend/src/components/Main.tsx
@@ -8,7 +8,7 @@ const Main: React.FC = () => {
   const authCtx = useContext(AuthContext);
 
   if (!authCtx.isLoggedIn) {
-    return <Navigate to="/auth" />;
+    return <Navigate to="/auth" replace={true} />;
   }
 
   return (

--- a/frontend/src/components/auth/AuthForm.tsx
+++ b/frontend/src/components/auth/AuthForm.tsx
@@ -42,7 +42,7 @@ const AuthForm: React.FC = () => {
       }
       setIsLoading(false);
       reset({ username: "", password: "" });
-      navigate("/");
+      navigate("/", { replace: true });
     } catch (err) {
       console.log(err);
       if (err instanceof AxiosError) {

--- a/frontend/src/contexts/auth-context.tsx
+++ b/frontend/src/contexts/auth-context.tsx
@@ -28,7 +28,7 @@ export const AuthContextProvider: React.FC<Props> = (props) => {
   const logoutHandler = () => {
     setToken("");
     setRefreshToken("");
-    navigate("/auth");
+    navigate("/auth", { replace: true });
   };
 
   const refreshTokenHandler = (token: string) => {


### PR DESCRIPTION
Before, browser history stacked up when you reload, login, or logout, which prohibited the user to go back to the page before visiting our site