### PR TITLE
docker: use buildx for frontend only for nginx

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -6,12 +6,7 @@ on:
 env:
   REPOSITORY: todo
 jobs:
-  buildx:
-    strategy:
-      matrix:
-        target:
-        - frontend
-        - api
+  build_api:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -31,6 +26,40 @@ jobs:
         docker buildx build \
           --push \
           --platform=linux/amd64,linux/arm64 \
-          -t ${{secrets.DOCKERHUB_USERNAME }}/${{ env.REPOSITORY }}-${{ matrix.target }} \
-          -t ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.REPOSITORY }}-${{ matrix.target }}:${{ github.sha }} \
-          ${{ matrix.target }}
+          -t ${{secrets.DOCKERHUB_USERNAME }}/${{ env.REPOSITORY }}-api \
+          -t ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.REPOSITORY }}-api:${{ github.sha }} \
+          api
+
+  build_frontend:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - uses: docker/setup-buildx-action@v2
+      with:
+        platforms: linux/amd64,linux/arm64
+
+    - name: Build and push the base image without Buildx (faster)
+      run: |
+        docker build \
+          --push \
+          --target todo-frontend-builder
+          -t ${{secrets.DOCKERHUB_USERNAME }}/${{ env.REPOSITORY }}-todo-frontend-builder \
+          -t ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.REPOSITORY }}-todo-frontend-builder:${{ github.sha }} \
+          frontend
+
+    - name: Build and push the production image with Buildx
+      run: |
+        docker buildx build \
+          --push \
+          --target production \
+          --platform=linux/amd64,linux/arm64 \
+          -t ${{secrets.DOCKERHUB_USERNAME }}/${{ env.REPOSITORY }}-frontend \
+          -t ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.REPOSITORY }}-frontend:${{ github.sha }} \
+          frontend

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,8 @@ clean:
 
 buildx:
 	docker buildx build --push --platform=linux/amd64,linux/arm64 -t $(DOCKER_USER)/$(APP_NAME)-api -t $(DOCKER_USER)/$(APP_NAME)-api:$(GIT_SHA) api
-	docker buildx build --push --platform=linux/amd64,linux/arm64 -t $(DOCKER_USER)/$(APP_NAME)-frontend -t $(DOCKER_USER)/$(APP_NAME)-frontend:$(GIT_SHA) frontend
+	docker build --push --target todo-frontend-builder -t $(DOCKER_USER)/$(APP_NAME)-frontend-builder -t $(DOCKER_USER)/$(APP_NAME)-frontend-builder:$(GIT_SHA) frontend/
+	docker buildx build --push --target production --platform=linux/amd64,linux/arm64 -t $(DOCKER_USER)/$(APP_NAME)-frontend -t $(DOCKER_USER)/$(APP_NAME)-frontend:$(GIT_SHA) frontend
 
 build:
 	docker build --push -t $(DOCKER_USER)/$(APP_NAME)-api -t $(DOCKER_USER)/$(APP_NAME)-api:$(GIT_SHA) api

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:20-alpine AS builder
+FROM node:20-alpine AS todo-frontend-builder
 WORKDIR /frontend
 COPY ./package.json ./package-lock.json ./
 RUN npm ci
 COPY . .
 RUN npm run build
 
-FROM nginx
+FROM nginx AS production
 EXPOSE 3000
 COPY ./nginx/default.conf /etc/nginx/conf.d/default.conf
-COPY --from=builder /frontend/build /usr/share/nginx/html
+COPY --from=ryojpn/todo-frontend-builder:latest /frontend/build /usr/share/nginx/html


### PR DESCRIPTION
Multi-stage build for frontend slows the building process on GitHub Actions when used with Buildx (QEMU).

The first stage is meant to create `build/` directory, so let's use Buildx only for the second stage, and copy the `build/` directory from an image built without Buildx for acceleration.