### PR TITLE
actions: use buildx for caching

### DIFF
--- a/.github/workflows/test-with-makefile.yml
+++ b/.github/workflows/test-with-makefile.yml
@@ -27,7 +27,7 @@ jobs:
           cache-to: type=gha,scope=$GITHUB_REF_NAME-frontend-dev,mode=max
 
       - name: Start frontend
-        run: docker compose -f docker-compose-dev.yml -f docker-compose-test-single.yml up -d --remove-orphans --build frontend
+        run: docker compose -f docker-compose-dev.yml -f docker-compose-test-single.yml up -d --remove-orphans frontend
 
       - name: Run test
         run: docker compose -f docker-compose-dev.yml exec -T frontend npm test -- --watchAll=false
@@ -51,7 +51,7 @@ jobs:
           cache-to: type=gha,scope=$GITHUB_REF_NAME-api-dev,mode=max
 
       - name: Start api
-        run: docker compose -f docker-compose-dev.yml -f docker-compose-test-single.yml up -d --remove-orphans --build api
+        run: docker compose -f docker-compose-dev.yml -f docker-compose-test-single.yml up -d --remove-orphans api
 
       - name: Run test
         run: docker compose -f docker-compose-dev.yml exec -T api npm test -- --watchAll=false

--- a/.github/workflows/test-with-makefile.yml
+++ b/.github/workflows/test-with-makefile.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Build the [frontend] image with cache
         uses: docker/build-push-action@v4
         with:
+          load: true
           context: frontend
           file: frontend/Dockerfile.dev
           cache-from: type=gha,scope=$GITHUB_REF_NAME-frontend-dev
@@ -45,6 +46,7 @@ jobs:
       - name: Build the [api] image with cache
         uses: docker/build-push-action@v4
         with:
+          load: true
           context: api
           file: api/Dockerfile.dev
           cache-from: type=gha,scope=$GITHUB_REF_NAME-api-dev

--- a/.github/workflows/test-with-makefile.yml
+++ b/.github/workflows/test-with-makefile.yml
@@ -24,14 +24,13 @@ jobs:
           load: true
           context: frontend
           file: frontend/Dockerfile.dev
+          tags: |
+            frontend-test
           cache-from: type=gha,scope=$GITHUB_REF_NAME-frontend-dev
           cache-to: type=gha,scope=$GITHUB_REF_NAME-frontend-dev,mode=max
 
-      - name: Start frontend
-        run: docker compose -f docker-compose-dev.yml -f docker-compose-test-single.yml up -d --remove-orphans frontend
-
       - name: Run test
-        run: docker compose -f docker-compose-dev.yml exec -T frontend npm test -- --watchAll=false
+        run: docker run --rm frontend-test npm test -- --watchAll=false
 
   test_api:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-with-makefile.yml
+++ b/.github/workflows/test-with-makefile.yml
@@ -14,5 +14,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - uses: docker/setup-buildx-action@v2
+        with:
+          driver: docker-container
+
+      - name: Build the [api] image with cache
+        uses: docker/build-push-action@v4
+        with:
+          context: api
+          file: api/Dockerfile.dev
+          cache-from: type=gha,scope=$GITHUB_REF_NAME-api-dev
+          cache-to: type=gha,scope=$GITHUB_REF_NAME-api-dev,mode=max
+
+      - name: Build the [frontend] image with cache
+        uses: docker/build-push-action@v4
+        with:
+          context: frontend
+          file: frontend/Dockerfile.dev
+          cache-from: type=gha,scope=$GITHUB_REF_NAME-frontend-dev
+          cache-to: type=gha,scope=$GITHUB_REF_NAME-frontend-dev,mode=max
+
       - name: Build and run the tests
         run: make test_single

--- a/.github/workflows/test-with-makefile.yml
+++ b/.github/workflows/test-with-makefile.yml
@@ -8,7 +8,31 @@ on:
     branches:
       - main
 jobs:
-  npm_test_with_docker_compose:
+  test_frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: docker/setup-buildx-action@v2
+        with:
+          driver: docker-container
+
+      - name: Build the [frontend] image with cache
+        uses: docker/build-push-action@v4
+        with:
+          context: frontend
+          file: frontend/Dockerfile.dev
+          cache-from: type=gha,scope=$GITHUB_REF_NAME-frontend-dev
+          cache-to: type=gha,scope=$GITHUB_REF_NAME-frontend-dev,mode=max
+
+      - name: Start frontend
+        run: docker-compose -f docker-compose-dev.yml -f docker-compose-test-single.yml up -d --remove-orphans --build frontend
+
+      - name: Run test
+        run: docker-compose -f docker-compose-dev.yml exec -T frontend npm test -- --watchAll=false
+
+  test_api:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -26,13 +50,8 @@ jobs:
           cache-from: type=gha,scope=$GITHUB_REF_NAME-api-dev
           cache-to: type=gha,scope=$GITHUB_REF_NAME-api-dev,mode=max
 
-      - name: Build the [frontend] image with cache
-        uses: docker/build-push-action@v4
-        with:
-          context: frontend
-          file: frontend/Dockerfile.dev
-          cache-from: type=gha,scope=$GITHUB_REF_NAME-frontend-dev
-          cache-to: type=gha,scope=$GITHUB_REF_NAME-frontend-dev,mode=max
+      - name: Start api
+        run: docker-compose -f docker-compose-dev.yml -f docker-compose-test-single.yml up -d --remove-orphans --build api
 
-      - name: Build and run the tests
-        run: make test_single
+      - name: Run test
+        run: docker-compose -f docker-compose-dev.yml exec -T api npm test -- --watchAll=false

--- a/.github/workflows/test-with-makefile.yml
+++ b/.github/workflows/test-with-makefile.yml
@@ -27,10 +27,10 @@ jobs:
           cache-to: type=gha,scope=$GITHUB_REF_NAME-frontend-dev,mode=max
 
       - name: Start frontend
-        run: docker-compose -f docker-compose-dev.yml -f docker-compose-test-single.yml up -d --remove-orphans --build frontend
+        run: docker compose -f docker-compose-dev.yml -f docker-compose-test-single.yml up -d --remove-orphans --build frontend
 
       - name: Run test
-        run: docker-compose -f docker-compose-dev.yml exec -T frontend npm test -- --watchAll=false
+        run: docker compose -f docker-compose-dev.yml exec -T frontend npm test -- --watchAll=false
 
   test_api:
     runs-on: ubuntu-latest
@@ -51,7 +51,7 @@ jobs:
           cache-to: type=gha,scope=$GITHUB_REF_NAME-api-dev,mode=max
 
       - name: Start api
-        run: docker-compose -f docker-compose-dev.yml -f docker-compose-test-single.yml up -d --remove-orphans --build api
+        run: docker compose -f docker-compose-dev.yml -f docker-compose-test-single.yml up -d --remove-orphans --build api
 
       - name: Run test
-        run: docker-compose -f docker-compose-dev.yml exec -T api npm test -- --watchAll=false
+        run: docker compose -f docker-compose-dev.yml exec -T api npm test -- --watchAll=false

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 DOCKER_USER = ryojpn
 APP_NAME = todo
 GIT_SHA = $(shell git rev-parse HEAD)
-DOCKER_COMPOSE = docker-compose
+DOCKER_COMPOSE = docker compose
 
 dev:
 	$(DOCKER_COMPOSE) -f docker-compose-dev.yml up --remove-orphans -d --build


### PR DESCRIPTION
I found [a Zenn post](https://zenn.dev/minedia/articles/2023-03-07-04d59908bc491d) that says the bulid of docker-compose was indeed accelerated by using buildx cache.

This PR intends to verify it, as this solves #19 